### PR TITLE
Switch deadlink validation with an env var

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -53,7 +53,8 @@ PLUGINS = [
     'tag_cloud',
 ]
 ## Deadlinks
-DEADLINK_VALIDATION = True
+if os.environ.get('DEADLINK_VALIDATION', True) != "False":
+    DEADLINK_VALIDATION = True
 DEADLINK_OPTS = {
     "classes": ['deadlink'],
 }


### PR DESCRIPTION
By default, the production deploys shouldn't test if the links
are dead.

Instead, we should do it early in the process, on the dev
environment.

To modify the behavior without changing the code, we should
put an env var.