### PR TITLE
Fix deadlinks

### DIFF
--- a/content/ansible-2.5-release.rst
+++ b/content/ansible-2.5-release.rst
@@ -58,7 +58,7 @@ Here is what I like and don't like about this release:
 help on irc!*
 
 .. _ansible 2.5 release notes: https://www.ansible.com/blog/ansible-2.5-traveling-space-and-time
-.. _ansible 2.5 changelog: https://github.com/ansible/ansible/blob/devel/CHANGELOG.md#2.5
+.. _ansible 2.5 changelog: https://github.com/ansible/ansible/blob/e8beb180e15eff1f54e0ac8a5a5143639794bbdc/CHANGELOG.md#2.5
 .. _ansible 2.5 porting guide: https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.5.html
 .. _in 2.5: http://docs.ansible.com/ansible/2.5/modules/stat_module.html
 .. _in 2.4: http://docs.ansible.com/ansible/2.4/stat_module.html

--- a/content/installing-a-multi-node-osa-cloud-in-the-cloud.md
+++ b/content/installing-a-multi-node-osa-cloud-in-the-cloud.md
@@ -222,7 +222,7 @@ Building overlays accross multiple datacenters/clouds is quite easy, and work by
 
 [ansible-dynamic-inventory]: http://docs.ansible.com/ansible/intro_dynamic_inventory.html
 [ansible-aws-dynamic-inventory]: https://raw.github.com/ansible/ansible/devel/contrib/inventory/ec2.py
-[ansible-openstack-dynamic-inventory]: https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/openstack.py
+[ansible-openstack-dynamic-inventory]: https://raw.githubusercontent.com/ansible/ansible/89ce826a9fb53c304238923a73667ab820711338/contrib/inventory/openstack_inventory.py
 [evrardjp-github-osa-cloud-multinode]: https://github.com/evrardjp/osa-cloud-multinode.git
 [osa]: https://github.com/openstack/openstack-ansible
 [bootstrap-host]: https://github.com/openstack/openstack-ansible/tree/master/tests/roles/bootstrap-host

--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -10,7 +10,6 @@ AUTHOR = u'Jean-Philippe Evrard'
 COPYRIGHT = AUTHOR
 SITENAME = u'dd if=/dev/brain of=/var/log/this.site'
 SITEURL = 'https://evrard.me'
-GOOGLE_ANALYTICS = "UA-79230364-1"
 
 PATH = 'content'
 
@@ -44,7 +43,7 @@ SOCIAL = (
 #          ('Python.org', 'http://python.org/'),
 #          ('Jinja2', 'http://jinja.pocoo.org/'))
 
-FOOTERTEXT = '<a href="pages/license.html">© 2017 %s</a>' % (AUTHOR)
+FOOTERTEXT = '<a href="%s/pages/license.html">© 2017 %s</a>' % (SITEURL, AUTHOR)
 
 # Plugins config
 PLUGIN_PATHS = ['plugins']

--- a/publishconf.py
+++ b/publishconf.py
@@ -11,6 +11,7 @@ sys.path.append(os.curdir)
 from pelicanconf import *
 
 SITEURL = 'https://evrard.me'
+GOOGLE_ANALYTICS = "UA-79230364-1"
 RELATIVE_URLS = False
 
 FEED_ALL_ATOM = 'feeds/all.atom.xml'

--- a/themes/JustRead/templates/base.html
+++ b/themes/JustRead/templates/base.html
@@ -107,7 +107,7 @@
 		{% else %}
 		© 2017 {{ AUTHOR }}
 		{% endif %}<br>
-		Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">Pelican</a>.</p>
+		Proudly powered by <a href="http://docs.getpelican.com/en/stable/">Pelican</a>.</p>
 	</div>
 </footer>
 	{% if GOOGLE_ANALYTICS %}


### PR DESCRIPTION
- Some links were relative to SITEURL, which caused issues when
  in pages/ folder.
- The google analytics was used on the development server
  configuration, which is not supposed to be recorded (later
  pointing to dead links)
- The template's link to Pelican's website was outdated, and is
  now updated towards the Pelican upstream documentation
- Ansible has moved files in their repositories, and references
  were using a branch instead of a sha.