### PR TITLE
Ensure all paragraphs have the same width

### DIFF
--- a/themes/JustRead/less/main.less
+++ b/themes/JustRead/less/main.less
@@ -456,7 +456,7 @@ blockquote, pre, .post ul, .post ol, p, .archive{
 // @media screen and (min-width: 888px)
 @media screen and (min-width: 55.5em) {
 
-	pre, .post > p, .post blockquote, .post ul, .post ol{
+	pre, .post p,.post > p, .post blockquote, .post ul, .post ol{
 		width: 400/6%; // target 4 columns, context 6 columns
 	}
 

--- a/themes/JustRead/static/css/main.css
+++ b/themes/JustRead/static/css/main.css
@@ -614,6 +614,7 @@ p,
 }
 @media screen and (min-width: 55.5em) {
   pre,
+  .post p,
   .post > p,
   .post blockquote,
   .post ul,


### PR DESCRIPTION
This prevents paragraphs from overflowing on the right compared to
ol/ul/or >p, as this is fairly ugly.