### PR TITLE
Add caching of static files through Cloudflare

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -28,3 +28,16 @@ HUGO_VERSION = "0.59.0"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"
+
+[[headers]]
+  for = "/img/*"
+  [headers.values]
+    Cache-Control = "public, s-max-age=604800"
+[[headers]]
+  for = "/*.css"
+  [headers.values]
+    Cache-Control = "public, s-max-age=604800"
+[[headers]]
+  for = "/*.js"
+  [headers.values]
+    Cache-Control = "public, s-max-age=604800"


### PR DESCRIPTION
The default Netlify cache-control header, are
"max-age=0, must-revalidate, public"

This is a problem as cloudflare cannot cache the content.

This fixes it by moving the content to a ``Cache-Control: public,
s-max-age=604800``. This takes precedence over max-age or the Expires header,
but it only applies to shared caches (e.g., proxies) and is ignored by a
private cache. This allow netlify to tell cloudfalre to cache assets for 7
days (css/images/js).